### PR TITLE
edit-sign-up

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,17 @@
+class UsersController < ApplicationController
+  def edit  
+  end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+end

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -1,13 +1,14 @@
 .side-bar
   .side-bar__user-name
     .top-items
-      .top-items__name masa
+      .top-items__name 
+        = current_user.name
       %ul.top-items__icons
         %li.top-items__icons--edit 
         = link_to "#" do
           = icon('far', 'edit')
         %li.top-items__icons--cog 
-        = link_to "#"  do
+        = link_to edit_user_path(current_user) do
           = icon('fas', 'cog')
   .side-bar__group-list
     .bottom-items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  get 'messages/index'
   root "messages#index"
+  resources :users, only: [:edit, :update]
 end


### PR DESCRIPTION
# what
サインアップ機能をフロント画面から遷移できるようにルーティングとコントローラーの設定、アイコンのリンクを編集した。

# why
アプリの基本的な機能としてログインしているユーザーを表示したり、一度登録したユーザーの情報を編集できる必要があるから。